### PR TITLE
Add conversion for longitude values to match NOAA

### DIFF
--- a/auroranoaa/__init__.py
+++ b/auroranoaa/__init__.py
@@ -24,6 +24,7 @@ class AuroraForecast:
   async def get_forecast_data(self, longitude:float, latitude:float):
     """Return a dict of the requested forecast data."""
     
+    longitude = longitude % 360 # Convert -180 to 180 to 360 longitudinal values 
     forecast_dict = {}
 
     async with await self._session.get(APIUrl) as resp:


### PR DESCRIPTION
I noticed that the NOAA uses 0 to 360 degrees for longitude values and not -180 to 180. This causes anyone in the western hemisphere to return 0 regardless of the forecast. This conversion will leave positive values alone and only convert negative values to match the format.